### PR TITLE
feat: add support for namespace-scoped sync (push/pull)

### DIFF
--- a/cmd/tome/cli/sync/sync.go
+++ b/cmd/tome/cli/sync/sync.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/spf13/cobra"
@@ -23,6 +24,8 @@ var SyncCmd = &cobra.Command{
 		target, _ := cmd.Flags().GetString(cliutil.FlagTo)
 		mode, _ := cmd.Flags().GetString(cliutil.FlagMode)
 		cfg, _ := config.Load()
+		namespace, _ := cmd.Flags().GetString(cliutil.FlagNamespace)
+		fmt.Printf("Namespace: %s\n", namespace)
 
 		backend, err = cliutil.ResolveRemote(target, cfg.DefaultRemote)
 		if err != nil {
@@ -35,22 +38,32 @@ var SyncCmd = &cobra.Command{
 		switch mode {
 		case "push":
 			logx.Info("📤 Pushing local data to remote...")
-			err = core.Sync(paths.TomeRoot(), backend)
+			if namespace != "" {
+				logx.Info("📂 Namespace: %s", namespace)
+				err = core.SyncNamespace(namespace, backend)
+			} else {
+				logx.Info("📦 Syncing all namespaces...")
+				err = core.Sync(paths.TomeRoot(), backend)
+			}
 		case "pull":
 			logx.Info("📥 Pulling from remote to local...")
-			err = core.Pull(paths.TomeRoot(), backend)
+			if namespace != "" {
+				logx.Info("📂 Namespace: %s", namespace)
+				err = core.PullNamespace(namespace, backend)
+			} else {
+				logx.Info("📦 Pulling all namespaces...")
+				err = core.Pull(paths.TomeRoot(), backend)
+			}
 		case "sync":
 			logx.Info("🔄 Bidirectional sync...")
 			err = core.SyncBidirectional(paths.TomeRoot(), backend)
 		default:
 			logx.Error("Unknown sync mode: %s", mode)
-			// log.Fatalf("Unknown sync mode: %s", mode)
 		}
 
 		if err != nil {
 			logx.Error("Sync failed: %v", err)
 			log.Fatalf("Sync aborted")
-			// log.Fatalf("Sync failed: %v", err)
 		}
 		logx.Success("✅ Sync complete")
 	},
@@ -59,4 +72,5 @@ var SyncCmd = &cobra.Command{
 func init() {
 	cliutil.AttachRemoteFlag(SyncCmd, cliutil.FlagTo)
 	cliutil.AttachModeFlag(SyncCmd)
+	cliutil.AttachNamespaceFlag(SyncCmd)
 }

--- a/internal/cliutil/flags.go
+++ b/internal/cliutil/flags.go
@@ -15,6 +15,7 @@ const (
 	FlagShorten     = "shorten"
 	FlagExclude     = "exclude"
 	FlagAll         = "all"
+	FlagNamespace   = "namespace"
 )
 
 func AttachOutputFlag(cmd *cobra.Command, defaultPath string, help ...string) *string {
@@ -55,6 +56,10 @@ func AttachShortenFlag(cmd *cobra.Command) *bool {
 
 func AttachExcludeFlag(cmd *cobra.Command) *[]string {
 	return attachStringArrayFlag(cmd, FlagExclude, "e", nil, "Exclude entries matching this pattern")
+}
+
+func AttachNamespaceFlag(cmd *cobra.Command) *string {
+	return attachStringFlag(cmd, FlagNamespace, "n", "", "Namespace to use for the operation")
 }
 
 func AttachAllFlag(cmd *cobra.Command) *bool {

--- a/internal/core/sync.go
+++ b/internal/core/sync.go
@@ -1,13 +1,80 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/kpiljoong/tome/internal/backend"
 	"github.com/kpiljoong/tome/internal/logx"
+	"github.com/kpiljoong/tome/internal/model"
 	"github.com/kpiljoong/tome/internal/paths"
 )
+
+func SyncNamespace(namespace string, remote backend.RemoteBackend) error {
+	logx.Section("🔄 Syncing namespace: %s", namespace)
+
+	blobIDs, err := getReferencedBlobs(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get referenced blobs: %w", err)
+	}
+
+	for _, blobID := range blobIDs {
+		blobPath := paths.BlobPath(blobID)
+		remotePath := filepath.Join(paths.RemoteBlobsPrefix, blobID)
+
+		if err := remote.UploadFile(blobPath, remotePath); err != nil {
+			logx.Warn("Failed to upload blob %s: %v", blobID, err)
+		}
+	}
+
+	journalPath := paths.NamespaceDir(namespace)
+	remotePrefix := paths.RemoteNamespacePrefix(namespace)
+
+	if err := remote.UploadDir(journalPath, remotePrefix); err != nil {
+		return fmt.Errorf("failed to upload journal for namespace: %s: %w", namespace, err)
+	}
+
+	return nil
+}
+
+func getReferencedBlobs(namespace string) ([]string, error) {
+	journalDir := paths.NamespaceDir(namespace)
+	files, err := os.ReadDir(journalDir)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]bool)
+	var blobIDs []string
+
+	for _, f := range files {
+		if f.IsDir() || !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
+		fullPath := filepath.Join(journalDir, f.Name())
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			logx.Warn("Faeild to read journal: %s", fullPath)
+			continue
+		}
+		var entry model.JournalEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			logx.Warn("Failed to parse journal: %s", fullPath)
+			continue
+		}
+
+		hash := entry.BlobHash
+		if hash != "" && !seen[hash] {
+			fmt.Printf("===== Found blob: %s\n", hash)
+			seen[hash] = true
+			blobIDs = append(blobIDs, hash)
+		}
+	}
+	return blobIDs, nil
+}
 
 func Sync(localPath string, remote backend.RemoteBackend) error {
 	logx.Section("🔄 Syncing blobs...")

--- a/internal/core/sync_pull.go
+++ b/internal/core/sync_pull.go
@@ -10,6 +10,54 @@ import (
 	"github.com/kpiljoong/tome/internal/paths"
 )
 
+func PullNamespace(namespace string, remote backend.RemoteBackend) error {
+	fmt.Printf("📥 Pulling namespace: %s\n", namespace)
+
+	journalRoot := paths.JournalsDir()
+	blobRoot := paths.BlobsDir()
+
+	_ = os.MkdirAll(filepath.Join(journalRoot, namespace), 0o755)
+	_ = os.MkdirAll(blobRoot, 0o755)
+
+	entries, err := remote.ListJournal(namespace, "")
+	if err != nil {
+		return fmt.Errorf("failed to list journal for namespace: %s: %w", namespace, err)
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(journalRoot, namespace, entry.ID+".json")
+		if _, err := os.Stat(entryPath); err == nil {
+			continue
+		}
+
+		blobPath := paths.BlobPath(entry.BlobHash)
+		if _, err := os.Stat(blobPath); os.IsNotExist(err) {
+			blob, err := remote.GetBlobByHash(entry.BlobHash)
+			if err != nil {
+				fmt.Printf("⚠️  Failed to fetch blob %s: %v\n", entry.BlobHash, err)
+				continue
+			}
+			if err := os.WriteFile(blobPath, blob, 0o644); err != nil {
+				fmt.Printf("⚠️  Failed to write blob file %s: %v\n", blobPath, err)
+			}
+		}
+
+		data, err := json.MarshalIndent(entry, "", "  ")
+		if err != nil {
+			fmt.Printf("⚠️  Failed to serialize journal entry %s: %v\n", entry.ID, err)
+			continue
+		}
+
+		if err := os.WriteFile(entryPath, data, 0o644); err != nil {
+			fmt.Printf("⚠️  Failed to write journal file %s: %v\n", entryPath, err)
+			continue
+		}
+
+		fmt.Printf("✅ Pulled: %s/%s\n", namespace, entry.Filename)
+	}
+	return nil
+}
+
 func Pull(localPath string, remote backend.RemoteBackend) error {
 	fmt.Println("Pulling from remote...")
 


### PR DESCRIPTION
Introduces the ability to sync a specific namespace independently, without affecting other data.

Changes
- tome sync --namespace <name> now only syncs blobs and journal entries under the specific namespace
- Works for both --mode push and --mode pull
- Falls back to full sync when --namespace is omitted
- Improved CLI log messages for clarity (e.g., syncing single namespace vs all)